### PR TITLE
Add documentation about required permissions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The structure and tests are adopted from `setup-hc-releases`.
 
 In order to use the `action-setup-enos` action and download the `enos` CLI, your repo needs to have a Github secret containing a token with `repo` scope. If your repo is already integrated with CRT, your `ELEVATED_GITHUB_TOKEN` should be sufficient for this. The only additional step is to ensure that your service account user associated with this token has read access to both the `action-setup-enos` [repo](https://github.com/hashicorp/action-setup-enos) and the `enos` [repo](https://github.com/hashicorp/enos). Reach out to the team on Slack in #team-quality to get your user added to both repos.
 
+**Note:** This token must also be "authorized" to the HashiCorp org via SSO. To do this, you would need to log in to Github as the service account user associated with the token, and follow [these instructions](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
+
 ### `setup-terraform` GitHub Action
 
 The `enos` CLI requires the `terraform` binary to be in the default `PATH`. Install the Terraform CLI using `setup-terraform` GitHub


### PR DESCRIPTION
### How to read this pull request
We realized that the service account associated with a repo's ELEVATED_GITHUB_TOKEN needs to be added with read access to both this repo and the Enos repo in order to use this Github action and the Enos CLI. I'm adding these instructions to the README.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [ ] I have written useful comments in the code
