### PR TITLE
[QT-474] Address deprecated set-output behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
      github-token:
        ${{ secrets.GITHUB_TOKEN }}
      version:
-       0.0.16
+       0.0.17
 - name: Check Enos version
   run: enos version
 ```
@@ -48,7 +48,7 @@ steps:
 The actions supports the following inputs:
 
 - `github-token`: The GitHub secret to use for access to Enos repos, with the permissions described above
-- `version`: The version of `enos` to install, defaulting to `0.0.16
+- `version`: The version of `enos` to install, defaulting to `0.0.17`
 
 # Update Enos Action
 To update the Enos Action run `npm run all` to compile and load the npm modules with the latest code updates.

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   version:
     description: Version of Enos CLI to install
     required: false
-    default: '0.0.16'
+    default: '0.0.17'
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -69,7 +69,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.16';
+const latestVersion = '0.0.17';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/enos.js
+++ b/enos.js
@@ -5,7 +5,7 @@ const githubRelease = require('./github-release');
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.16';
+const latestVersion = '0.0.17';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/hashicorp/action-setup-enos#readme",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@actions/tool-cache": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-enos",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Setup Enos CLI for GitHub Actions",
   "main": "action.js",
   "scripts": {


### PR DESCRIPTION
### How to read this pull request
[Slack convo that started this change](https://hashicorp.slack.com/archives/C016MAUKHG8/p1675206092475509)

Michael Li mentioned that the set-output deprecation error was showing for some of Boundary's workflows.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

While it initially seemed that this may only be related to how the workflow's commands worked, [GitHub has provided info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows) for action maintainers and how to update for this change as well.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [na] I have written useful comments in the code
