### PR TITLE
Revert Enos version refs to 0.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
      github-token:
        ${{ secrets.GITHUB_TOKEN }}
      version:
-       0.0.17
+       0.0.16
 - name: Check Enos version
   run: enos version
 ```
@@ -48,7 +48,7 @@ steps:
 The actions supports the following inputs:
 
 - `github-token`: The GitHub secret to use for access to Enos repos, with the permissions described above
-- `version`: The version of `enos` to install, defaulting to `0.0.17`
+- `version`: The version of `enos` to install, defaulting to `0.0.16`
 
 # Update Enos Action
 To update the Enos Action run `npm run all` to compile and load the npm modules with the latest code updates.

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   version:
     description: Version of Enos CLI to install
     required: false
-    default: '0.0.17'
+    default: '0.0.16'
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -69,7 +69,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.17';
+const latestVersion = '0.0.16';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/enos.js
+++ b/enos.js
@@ -5,7 +5,7 @@ const githubRelease = require('./github-release');
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.17';
+const latestVersion = '0.0.16';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-enos",
-  "version": "0.0.17",
+  "version": "0.0.16",
   "description": "Setup Enos CLI for GitHub Actions",
   "main": "action.js",
   "scripts": {


### PR DESCRIPTION
### How to read this pull request
Previously, I had bumped the Enos version to 0.0.17 mistakenly assuming this was the action version and not the Enos version. This change reverts it back to 0.0.16.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [na] I have written useful comments in the code
