### PR TITLE
Fix enos download race condition, add validation workflow, update release workflow

### DIFF
--- a/.github/workflows/tagrelease.yml
+++ b/.github/workflows/tagrelease.yml
@@ -25,7 +25,7 @@ jobs:
           git config --global user.name "QTI Team"
       - name: Tag Release
         run: |
-          TAG="v$(cat package.json| jq -r '.version')"
-          git tag -a -m "$TAG" $TAG
+          TAG="v$(jq -r '.version' < package.json)"
+          git tag -a -m "$TAG" "$TAG"
           git tag -a -m "$TAG" v1 -f
           git push --tags -f

--- a/.github/workflows/tagrelease.yml
+++ b/.github/workflows/tagrelease.yml
@@ -1,10 +1,10 @@
 name: "Tag Release"
 
 on:
-  # Run this workflow only when dist/index.js is updated
+  # Run this workflow only when package.json is updated
   push:
     paths:
-      - 'dist/index.js'
+      - "package.json"
     branches:
       - main
 
@@ -17,21 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}   # checkout the correct branch name
-          fetch-depth: 0                # fetch the whole repo history
+          ref: ${{ github.head_ref }} # checkout the correct branch name
+          fetch-depth: 0 # fetch the whole repo history
       - name: Setup GitHub User
         run: |
           git config --global user.email "team-secure-quality@hashicorp.com"
           git config --global user.name "QTI Team"
       - name: Tag Release
         run: |
-          TAG=$(git tag -l |awk -F. '{print $2}'|sort -n |tail -n 1)
-          echo $TAG
-          TAG1=$(echo $TAG+1 | bc)
-          echo $TAG1
-          export UPDATED_TAG="v1.$TAG1"
-          git tag -a -m "$UPDATED_TAG" $UPDATED_TAG
-          git tag -a -m "$UPDATED_TAG" v1 -f
+          TAG="v$(cat package.json| jq -r '.version')"
+          git tag -a -m "$TAG" $TAG
+          git tag -a -m "$TAG" v1 -f
           git push --tags -f
-
-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,8 +17,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: "Run tests"
-        run: npm install && npm test
+      - name: "NPM Install"
+        run: npm install
+      - name: "ESLint"
+        run: npm run lint
+      - name: "NPM Test"
+        run: npm test
       - name: "Validate action installation"
         uses: ./ #this took a full day to figure out and I hate it
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,13 @@ jobs:
         uses: ./ #this took a full day to figure out and I hate it
         with:
           github-token: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
+      - name: "Check package.json version is not in released tags"
+        run: |
+          TAG=$(cat package.json| jq -r ".version")
+          if git tag -l | grep -q "v$TAG"; then
+            echo "Version $TAG already released, update package.json!";
+            exit 1
+          fi
       - name: "Check action & latest released versions"
         env:
           GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: "Run npm tests"
+      - name: "Run tests"
         run: npm install && npm test
-      - name: "Run action itself"
+      - name: "Validate action installation"
         uses: ./ #this took a full day to figure out and I hate it
         with:
           github-token: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
+      - name: "Check action & latest released versions"
+        env:
+          GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}
+        run: |
+          version=$(enos version)
+          latest=$(gh release view -R hashicorp/enos --json tagName --jq '.tagName')
+          if [[ "v${version}" != "${latest}" ]];
+          then
+            echo "Action installed version ${version} when ${latest} is latest!";
+            exit 1;
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+---
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  verify:
+    name: "Validate Action"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: "Run npm tests"
+        run: npm install && npm test
+      - name: "Run action itself"
+        uses: ./ #this took a full day to figure out and I hate it
+        with:
+          github-token: ${{ secrets.SERVICE_USER_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ To update the Enos Action run `npm run all` to compile and load the npm modules 
 
 # Release Process
 To release the updated version of Enos Action run the following steps:
-1. Replace the `Enos` version in following files:
+1. Update the `Enos` version to the [latest release](https://github.com/hashicorp/enos/releases) in following files:
     -  README.md
-    -  action.yml
     -  enos.js
+2. Update the `action-setup-enos` version in
     -  package.json
-1. Run `npm run all`
-1. Create a PR with updated files above and the generated `dist/index.js`
-1. Get reviewed and the PR merged
-1. (Automated with `tagrelease` GitHub Actions Workflow) Add github tags to `main` branch and force update `v1` tag by running the following commands
+3. Run `npm run all`
+4. Create a PR with updated files above and the generated `dist/index.js`
+5. Get reviewed and the PR merged
+6. (Automated with `tagrelease` GitHub Actions Workflow) Add github tags to `main` branch and force update `v1` tag by running the following commands
    - `git tag -a -m "v1.5" v1.5`
    - `git tag -a -m "v1.5" v1 -f`
    - `git push --tags -f`

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ To release the updated version of Enos Action run the following steps:
     -  enos.js
 2. Update the `action-setup-enos` version in
     -  package.json
-3. Run `npm run all`
+3. Run `npm install && npm run all`
 4. Create a PR with updated files above and the generated `dist/index.js`
 5. Get reviewed and the PR merged
 6. (Automated with `tagrelease` GitHub Actions Workflow) Add github tags to `main` branch and force update `v1` tag by running the following commands
-   - `git tag -a -m "v1.5" v1.5`
-   - `git tag -a -m "v1.5" v1 -f`
+   - `TAG="v$(cat package.json| jq -r '.version')"`
+   - `git tag -a -m "$TAG" $TAG`
+   - `git tag -a -m "$TAG" v1 -f`
    - `git push --tags -f`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
      github-token:
        ${{ secrets.GITHUB_TOKEN }}
      version:
-       0.0.17
+       0.0.18
 - name: Check Enos version
   run: enos version
 ```
@@ -48,7 +48,7 @@ steps:
 The actions supports the following inputs:
 
 - `github-token`: The GitHub secret to use for access to Enos repos, with the permissions described above
-- `version`: The version of `enos` to install, defaulting to `0.0.17`
+- `version`: The version of `enos` to install, defaulting to `0.0.18`
 
 # Update Enos Action
 To update the Enos Action run `npm run all` to compile and load the npm modules with the latest code updates.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
      github-token:
        ${{ secrets.GITHUB_TOKEN }}
      version:
-       0.0.18
+       0.0.16
 - name: Check Enos version
   run: enos version
 ```
@@ -48,7 +48,7 @@ steps:
 The actions supports the following inputs:
 
 - `github-token`: The GitHub secret to use for access to Enos repos, with the permissions described above
-- `version`: The version of `enos` to install, defaulting to `0.0.18`
+- `version`: The version of `enos` to install, defaulting to `0.0.16`
 
 # Update Enos Action
 To update the Enos Action run `npm run all` to compile and load the npm modules with the latest code updates.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: Version of Enos CLI to install
     required: false
-    default: '0.0.16'
+    default: '0.0.18'
 runs:
   using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,6 @@ inputs:
   version:
     description: Version of Enos CLI to install
     required: false
-    default: '0.0.16'
 runs:
   using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: Version of Enos CLI to install
     required: false
-    default: '0.0.18'
+    default: '0.0.16'
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -197,7 +197,6 @@ async function downloadAsset(client, owner, repo, releaseAsset, directory) {
             throw 'Not Found'
         }
 
-        // I'm now no longer 100% sure this was the culprit, lets log just in case it bites us again
         client.log.info(`Release asset ${releaseAsset.name} size: ${response.rawBody.length}`);
         if (response.rawBody.length == 0) {
             throw 'Empty Asset'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,13 +1,13 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
- */
-
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 4582:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 const process = __nccwpck_require__(7282);
 const core = __nccwpck_require__(2186);
@@ -66,6 +66,11 @@ module.exports = run;
 
 /***/ 4344:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 const exec = __nccwpck_require__(1514);
 const tc = __nccwpck_require__(7784);
@@ -152,6 +157,11 @@ exports.versionNumber = versionNumber;
 
 /***/ 3098:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 const fs = __nccwpck_require__(7147);
 const path = __nccwpck_require__(1017);
@@ -23970,6 +23980,11 @@ function wrappy (fn, cb) {
 /***/ 1261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const core = __nccwpck_require__(2186);
 const { GitHub, getOctokitOptions } = __nccwpck_require__(3030)
 const { retry } = __nccwpck_require__(6298)
@@ -24251,6 +24266,11 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const action = __nccwpck_require__(4582);
 
 async function run() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79,7 +79,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.18';
+const latestVersion = '0.0.16';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   try {

--- a/enos.js
+++ b/enos.js
@@ -10,7 +10,7 @@ const githubRelease = require('./github-release');
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.18';
+const latestVersion = '0.0.16';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   try {

--- a/enos.js
+++ b/enos.js
@@ -10,7 +10,7 @@ const githubRelease = require('./github-release');
 const executableName = 'enos';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'enos';
-const latestVersion = '0.0.16';
+const latestVersion = '0.0.18';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   try {

--- a/enos.js
+++ b/enos.js
@@ -13,7 +13,12 @@ const gitHubRepositoryRepo = 'enos';
 const latestVersion = '0.0.16';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
-  return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);
+  try {
+    return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);
+    } catch (err) {
+      client.log.error(`Unable to download release asset: ${releaseAsset.name}: ${err}`)
+      throw err
+   }
 }
 
 async function extractReleaseAsset(client, downloadPath) {

--- a/enos.test.js
+++ b/enos.test.js
@@ -64,8 +64,8 @@ describe('download release asset', () => {
         .reply(404, 'Not Found');
 
       const enos = require('./enos')
-
-      await expect(enos.downloadReleaseAsset(client, releaseAsset, directory)).rejects.toThrow('Not Found');
+      const result = enos.downloadReleaseAsset(client, releaseAsset, directory)
+      await expect(result).rejects.toThrow('Not Found');
     });
   });
 });

--- a/github-release.js
+++ b/github-release.js
@@ -32,7 +32,6 @@ async function downloadAsset(client, owner, repo, releaseAsset, directory) {
             throw 'Not Found'
         }
 
-        // I'm now no longer 100% sure this was the culprit, lets log just in case it bites us again
         client.log.info(`Release asset ${releaseAsset.name} size: ${response.rawBody.length}`);
         if (response.rawBody.length == 0) {
             throw 'Empty Asset'

--- a/github-release.js
+++ b/github-release.js
@@ -13,15 +13,13 @@ async function downloadAsset(client, owner, repo, releaseAsset, directory) {
 
     try {
         const downloadPath = path.resolve(directory, releaseAsset.name);
-        const file = fs.createWriteStream(downloadPath);
-        
         // Workaround since oktokit asset downloads are broken https://github.com/octokit/core.js/issues/415
         const githubToken = core.getInput('github-token');
 
         if (typeof releaseAsset.url === "undefined") { // template url for tests
             releaseAsset.url = `https://api.github.com/repos/${owner}/${repo}/releases/assets/${releaseAsset.id}`;
         }
-        
+
         const response = await got(releaseAsset.url, {
                 method: 'GET',
                 headers: {
@@ -34,8 +32,13 @@ async function downloadAsset(client, owner, repo, releaseAsset, directory) {
             throw 'Not Found'
         }
 
-        file.write(Buffer.from(response.rawBody));
-        file.end();
+        // I'm now no longer 100% sure this was the culprit, lets log just in case it bites us again
+        client.log.info(`Release asset ${releaseAsset.name} size: ${response.rawBody.length}`);
+        if (response.rawBody.length == 0) {
+            throw 'Empty Asset'
+        }
+
+        await fs.promises.writeFile(downloadPath, Buffer.from(response.rawBody));
 
         return downloadPath;
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-setup-enos",
-  "version": "0.0.16",
+  "version": "1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-setup-enos",
-      "version": "0.0.16",
+      "version": "1.18",
       "license": "MPL-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,7 +1653,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "node_modules/babel-jest": {
@@ -1965,7 +1965,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -2011,7 +2011,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -2123,7 +2123,7 @@
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "node_modules/deep-is": {
@@ -2152,7 +2152,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -2301,7 +2301,7 @@
     "node_modules/escodegen/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -2331,7 +2331,7 @@
     "node_modules/escodegen/node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -2340,7 +2340,7 @@
     "node_modules/escodegen/node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -2564,7 +2564,7 @@
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -2600,7 +2600,7 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "node_modules/fastq": {
@@ -2697,7 +2697,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -2995,7 +2995,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -3004,7 +3004,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -3020,7 +3020,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "node_modules/is-core-module": {
@@ -3038,7 +3038,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3121,13 +3121,13 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3948,13 +3948,13 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "node_modules/json5": {
@@ -4160,7 +4160,7 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "node_modules/nock": {
@@ -4219,7 +4219,7 @@
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node_modules/node-releases": {
@@ -4269,7 +4269,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
       }
@@ -4401,7 +4401,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4652,7 +4652,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4874,7 +4874,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "node_modules/stack-utils": {
@@ -5043,7 +5043,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "node_modules/throat": {
@@ -5061,7 +5061,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5359,7 +5359,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -6771,7 +6771,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "babel-jest": {
@@ -7000,7 +7000,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -7036,7 +7036,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "convert-source-map": {
@@ -7123,7 +7123,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-is": {
@@ -7146,7 +7146,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "deprecation": {
@@ -7255,7 +7255,7 @@
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -7279,13 +7279,13 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
           "dev": true
         },
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -7448,7 +7448,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expect": {
@@ -7478,7 +7478,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
@@ -7557,7 +7557,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
@@ -7770,13 +7770,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -7792,7 +7792,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-core-module": {
@@ -7807,7 +7807,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -7863,13 +7863,13 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -8510,13 +8510,13 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -8674,7 +8674,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "nock": {
@@ -8721,7 +8721,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-releases": {
@@ -8759,7 +8759,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
       }
@@ -8852,7 +8852,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
@@ -9027,7 +9027,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "requires-port": {
@@ -9185,7 +9185,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stack-utils": {
@@ -9308,7 +9308,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throat": {
@@ -9326,7 +9326,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-regex-range": {
@@ -9546,7 +9546,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-enos",
-  "version": "0.0.16",
+  "version": "1.18",
   "description": "Setup Enos CLI for GitHub Actions",
   "main": "action.js",
   "scripts": {


### PR DESCRIPTION
### How to read this pull request
Per QT-451, we've occasionally seen failures running this action, ending with
```Error: Unable to extract release asset (/home/runner/work/_temp/enos_0.0.15_linux_amd64.zip): Error: The process '/usr/bin/unzip' failed with exit code 9```

My initial suspicion was a `200 OK` and github actions returning an empty payload, but after testing and failing to repro, I took another look and found we potentially trying to write the output zipfile before the asset had been downloaded fully (or at all.) I added some logging just in case we start actually getting short-length responses from GHA.

Additionally we took the time to add a much-needed validation workflow to this repo, testing the action itself as part of the workflow and validating that it is currently referencing the latest released Enos version.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
