### PR TITLE
release: enos 0.0.31 for reals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-setup-enos",
-  "version": "1.35",
+  "version": "1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-setup-enos",
-      "version": "1.35",
+      "version": "1.36",
       "license": "MPL-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-enos",
-  "version": "1.35",
+  "version": "1.36",
   "description": "Setup Enos CLI for GitHub Actions",
   "scripts": {
     "all": "npm run build && npm run ci",


### PR DESCRIPTION
I forgot to bump the version in `package.json` when attempting to release 0.0.31. This fixes that.