### PR TITLE
actions: update permissions for tagrelease workflow

### DIFF
--- a/.github/workflows/tagrelease.yml
+++ b/.github/workflows/tagrelease.yml
@@ -7,6 +7,10 @@ on:
       - "package.json"
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   tag-release:


### PR DESCRIPTION
### How to read this pull request

Update the permissions on the tagrelease workflow. I think this ought to be enough but chicken and egg and all that. At the very least it'll make the workflow runnable with workflow_dispatch so we can test it and do a fast follow if more permissions are necessary.

### Checklist

- [ ] The commit message includes an explanation of the changes
- [ ] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [ ] I have performed a self-review of the changes
- [ ] I have made necessary changes and/or pull requests for documentation
- [ ] I have written useful comments in the code

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
